### PR TITLE
main,renderer: add 'lossless' quality

### DIFF
--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -132,7 +132,7 @@ export function getRecommendSongs() {
     });
 }
 
-/** 
+/**
  * 每日歌曲推荐 -> 不感兴趣
  * @param {number} id
  * @returns {Promise<Types.DislikeRecommendRes>}
@@ -219,6 +219,7 @@ export function getPicUrl(id, cdn = 3) {
 }
 
 const QualityMap = {
+    ex: 999000,
     h: 320000,
     m: 192000,
     l: 128000
@@ -231,7 +232,7 @@ const QualityMap = {
  * @returns {Promise<Types.MusicUrlRes>}
  */
 export function getMusicUrlW(idOrIds, quality) {
-    if (!QualityMap[quality]) throw new Error(`Quality type '${quality}' is not in [h,m,l]`);
+    if (!QualityMap[quality]) throw new Error(`Quality type '${quality}' is not in [ex,h,m,l]`);
     let ids;
     if (Array.isArray(idOrIds)) ids = idOrIds;
     else ids = [idOrIds];
@@ -248,7 +249,7 @@ export function getMusicUrlW(idOrIds, quality) {
  * @returns {Promise<Types.MusicUrlRes>}
  */
 export function getMusicUrlL(idOrIds, quality) {
-    if (!QualityMap[quality]) throw new Error(`Quality type '${quality}' is not in [h,m,l]`);
+    if (!QualityMap[quality]) throw new Error(`Quality type '${quality}' is not in [ex,h,m,l]`);
     let ids;
     if (Array.isArray(idOrIds)) ids = idOrIds;
     else ids = [idOrIds];
@@ -265,7 +266,7 @@ export function getMusicUrlL(idOrIds, quality) {
  * @returns {Promise<Types.MusicUrlRes>}
  */
 export function getMusicUrlE(idOrIds, quality) {
-    if (!QualityMap[quality]) throw new Error(`Quality type '${quality}' is not in [h,m,l]`);
+    if (!QualityMap[quality]) throw new Error(`Quality type '${quality}' is not in [ex,h,m,l]`);
     let ids;
     if (Array.isArray(idOrIds)) ids = idOrIds;
     else ids = [idOrIds];
@@ -1174,7 +1175,7 @@ export function addRadioTrashE(songId, time) {
 
 /**
  * @param {number} limit
- * @param {number} addTime 
+ * @param {number} addTime
  * @returns {Promise<Types.RadioTrashERes>}
  */
 export function getRadioTrashE(limit, addTime) {

--- a/src/main/api/types.d.ts
+++ b/src/main/api/types.d.ts
@@ -1,6 +1,6 @@
 namespace Types {
     export type CacheType = 'all' | 'music';
-    export type MusicQuality = 'h' | 'm' | 'l';
+    export type MusicQuality = 'ex' | 'h' | 'm' | 'l';
 
     interface ApiRes {
         code: number;
@@ -1115,7 +1115,7 @@ namespace Types {
     }
 
     export interface SubscribeAlbumRes extends ApiRes {
-        /** 
+        /**
          * error message
          * - `200` 该专辑已在用户收藏列表中
          */
@@ -1125,7 +1125,7 @@ namespace Types {
     }
 
     export interface UnsubscribeAlbumRes extends ApiRes {
-        /** 
+        /**
          * error message
          * - `404` 用户未未收藏此专辑
          */

--- a/src/renderer/page/Settings/Settings.vue
+++ b/src/renderer/page/Settings/Settings.vue
@@ -185,6 +185,11 @@ export default {
                         case 'exitOnWindowClose':
                             ipcRenderer.send(IpcTag, key, val);
                             break;
+                        case 'bitRate':
+                            if(val === 'ex') {
+                                this.$toast.message('实际播放码率取决于歌曲最高码率和帐号最高可播放码率');
+                            }
+                            break;
                     }
                 }
             });

--- a/src/renderer/page/Settings/entries.js
+++ b/src/renderer/page/Settings/entries.js
@@ -83,6 +83,7 @@ export const Entries = [
                 title: '音频码率',
                 prop: 'bitRate',
                 options: [
+                    { label: '最高', value: 'ex' },
                     { label: '极高 (320 kbit/s)', value: 'h' },
                     { label: '较高 (192 kbit/s)', value: 'm' },
                     { label: '标准 (128 kbit/s)', value: 'l' },


### PR DESCRIPTION
添加 "最高" 码率选项; 传递 `br` 为 `999000` 时获取小于等于 "无损音质(flac)" 的音频文件链接。

仅"音乐包"以上类型用户有可能获取到 flac 质量的音频，普通用户会 fallback 到 320kbps 及之下