### PR TITLE
fix download filename on windows

### DIFF
--- a/src/main/api/downloader.js
+++ b/src/main/api/downloader.js
@@ -16,6 +16,9 @@ const d = debug('Downloader');
  * @param {string} text 
  */
 function escapeSlash(text) {
+    if (process.platform === 'win32') {
+        return text.replace(/[<>:"\/\\\|\?\*]/g, ' ');
+    }
     return text.replace(/\//g, ' ');
 }
 


### PR DESCRIPTION
由于 Windows 对文件名的规则，一些含有特殊字符（比如冒号）的歌曲在下载后无法正确创建文件。于是对于可能会出现在歌名中的特殊字符进行了替换处理。

可以使用 https://music.163.com/song/28575898 复现此问题。