### PR TITLE
main: move musicCache to a cache folder

### DIFF
--- a/src/main/api/cache.js
+++ b/src/main/api/cache.js
@@ -12,7 +12,7 @@ class Cache {
     constructor(path, configPath) {
         if (typeof path === 'string') {
             if (!fs.existsSync(path)) {
-                fs.mkdirSync(path);
+                fs.mkdirSync(path, {recursive: true});
             } else if (!fs.statSync(path).isDirectory()) {
                 throw new Error(`[Cache] '${path} was token by unknown file. Please remove it manually.'`);
             }

--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -20,9 +20,10 @@ const BaseURL = 'https://music.163.com';
 const client = new Client();
 
 const dataPath = app.getPath('userData');
+const cachePath = app.getPath('cache');
 const CachePath = {
     all: dataPath,
-    music: path.join(dataPath, 'musicCache')
+    music: path.join(cachePath, 'electron-netease-cloud-music' ,'musicCache')
 };
 const musicCache = new Cache(CachePath.music, dataPath);
 migrate();

--- a/src/main/api/migrate.js
+++ b/src/main/api/migrate.js
@@ -13,6 +13,12 @@ function clearLegacyLyricCache() {
     });
 }
 
+function clearLegacyMusicCache() {
+    const dataPath = app.getPath('userData');
+    fs.rmSync(path.join(dataPath, 'musicCache'), {recursive: true, force: true});
+}
+
 export default function migrate() {
     clearLegacyLyricCache();
+    clearLegacyMusicCache();
 }


### PR DESCRIPTION
main: move musicCache to a cache folder

Move music cache to a cache folder. Delete the old cache.

Resolves: https://github.com/Rocket1184/electron-netease-cloud-music/issues/124