### PR TITLE
feat: support the music cache limit

### DIFF
--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -24,7 +24,7 @@ const CachePath = {
     all: dataPath,
     music: path.join(dataPath, 'musicCache')
 };
-const musicCache = new Cache(CachePath.music, dataPath);
+const musicCache = new Cache(CachePath.music, dataPath, Settings.getSync().musicCacheLimit*1024*1024);
 migrate();
 
 const musicServer = new MusicServer(musicCache);
@@ -521,6 +521,22 @@ export async function getDataSize(type) {
 export async function clearCache(type) {
     try {
         await clearDirectory(CachePath[type]);
+    } catch (e) {
+        return {
+            ok: false,
+            msg: e.stack
+        };
+    }
+    return { ok: true };
+}
+
+/**
+ * @param {Types.CacheType} size cache limit in bytes
+ * @returns {Promise<{ok: boolean; msg?: string}>}
+ */
+export async function setMusicCacheLimit(size) {
+    try {
+        await musicServer.cache.setCacheLimit(size);
     } catch (e) {
         return {
             ok: false,

--- a/src/main/api/musicServer.js
+++ b/src/main/api/musicServer.js
@@ -153,7 +153,7 @@ class MusicServer {
             d('Got URL for music id=%d', id);
             const musicRes = await this.cache.fetch(music.url.replace(/^http:/, 'https:'));
             // TODO: write file only md5 matches
-            musicRes.body.pipe(fs.createWriteStream(this.cache.internalPath(fileName)));
+            musicRes.body.pipe(this.cache.writeStream(fileName));
 
             const range = MusicServer.getRange(req, +musicRes.headers.get('content-length'));
             res.writeHead(206, MusicServer.buildHeaders(range));

--- a/src/main/settings.js
+++ b/src/main/settings.js
@@ -24,7 +24,8 @@ export const defaultSettings = {
     themePrimaryColor: '#7e57c2',
     themeSecondaryColor: '#ff4081',
     themeVariety: 'auto',
-    autoReplacePlaylist: false
+    autoReplacePlaylist: false,
+    musicCacheLimit: 512,
 };
 
 /**
@@ -44,8 +45,16 @@ function writeFile(target) {
     return fsp.writeFile(configPath, JSON.stringify(target, null, 4), 'utf8');
 }
 
+function writeFileSync(target) {
+    return fs.writeFileSync(configPath, JSON.stringify(target, null, 4), 'utf8');
+}
+
 function readFile() {
     return fsp.readFile(configPath, 'utf8');
+}
+
+function readFileSync() {
+    return fs.readFileSync(configPath, 'utf8');
 }
 
 export async function set(target) {
@@ -57,6 +66,15 @@ export async function set(target) {
     return writeFile(target);
 }
 
+export function setSync(target) {
+    try {
+        fs.accessSync(configDir);
+    } catch (e) {
+        fs.mkdirSync(configDir);
+    }
+    return writeFileSync(target);
+}
+
 export async function get() {
     let settings = defaultSettings;
     try {
@@ -65,6 +83,18 @@ export async function get() {
         settings = trimSettings(json);
     } catch (e) {
         set(defaultSettings);
+    }
+    return settings;
+}
+
+export function getSync() {
+    let settings = defaultSettings;
+    try {
+        fs.accessAsync(configPath);
+        const json = JSON.parse(readFileSync());
+        settings = trimSettings(json);
+    } catch (e) {
+        setSync(defaultSettings);
     }
     return settings;
 }

--- a/src/renderer/page/Settings/Settings.vue
+++ b/src/renderer/page/Settings/Settings.vue
@@ -81,6 +81,10 @@ export default {
             Api.getDataSize('all').then(s => this.dataSize = humanSize(s.size));
             Api.getDataSize('music').then(s => this.musicSize = humanSize(s.size));
         },
+        setMusicCacheLimit(size) {
+            Api.setMusicCacheLimit(size);
+            Api.getDataSize('music').then(s => this.musicSize = humanSize(s.size));
+        },
         initData() {
             this.refreshSize();
             Api.getVersionName().then(v => this.versionName = v);
@@ -200,6 +204,9 @@ export default {
                             if (val === 'ex') {
                                 this.$toast.message('实际下载码率取决于歌曲最高码率和帐号最高可播放码率');
                             }
+                            break;
+                        case 'musicCacheLimit':
+                            this.setMusicCacheLimit(val*1024*1024);
                             break;
                     }
                 }

--- a/src/renderer/page/Settings/entries.js
+++ b/src/renderer/page/Settings/entries.js
@@ -164,6 +164,18 @@ export const Entries = [
                 handler: 'promptClearMusicCache'
             },
             {
+                type: 'select',
+                title: '歌曲缓存空间限制',
+                prop: 'musicCacheLimit',
+                options: [
+                    { label: '无限制', value: 0 },
+                    { label: '128 MiB', value: 128 },
+                    { label: '256 MiB', value: 256 },
+                    { label: '512 MiB', value: 512 },
+                    { label: '1 GiB', value: 1024 },
+                ]
+            },
+            {
                 type: 'plain',
                 title: '所有应用数据',
                 data: 'dataSize',


### PR DESCRIPTION
Add an option to support the music cache limit. The least recently accessed cache will be deleted.

Resolves: https://github.com/Rocket1184/electron-netease-cloud-music/issues/44