### PR TITLE
Control lyrics scrolling with mouse wheel and Adjust radio playback logic

### DIFF
--- a/src/renderer/store/actions.js
+++ b/src/renderer/store/actions.js
@@ -922,11 +922,12 @@ export function clearRadio({ commit, dispatch }) {
  */
 export async function getRadio({ commit }) {
     const resp = await Api.getRadioE();
+    const tracks = [];
     if (resp.code === 200) {
         const a = { source: { name: 'radio' } };
-        const tracks = resp.data.map(t => new Track(t, a));
-        commit(types.APPEND_RADIO, { tracks });
+        tracks.push(...resp.data.map(t => new Track(t, a)));
     }
+    commit(types.APPEND_RADIO, { tracks });
 }
 
 /**

--- a/src/renderer/store/modules/radio.js
+++ b/src/renderer/store/modules/radio.js
@@ -29,16 +29,22 @@ const mutations = {
     [types.CLEAR_RADIO](state) {
         state.list = [];
         state.index = 0;
+        trackIdSet.clear();
     },
     [types.APPEND_RADIO](state, /** @type {{ tracks: Models.Track[] }} */ { tracks }) {
-        const toAppend = [];
+        if (tracks.length === 0) {
+            tracks.push(state.list[0]);
+        }
         for (const t of tracks) {
-            if (!trackIdSet.has(t.id)) {
+            if (trackIdSet.has(t.id)) {
+                const duplicate = state.list.findIndex(s => s.id === t.id);
+                state.list.splice(duplicate, 1);
+                if (duplicate < state.index) state.index--;
+            } else {
                 trackIdSet.add(t.id);
-                toAppend.push(t);
             }
         }
-        state.list.push.apply(state.list, toAppend);
+        state.list.push.apply(state.list, tracks);
         if (state.list.length > RADIO_MAX_SIZE) {
             const removeCount = state.list.length - RADIO_MAX_SIZE;
             const removed = state.list.splice(0, removeCount);


### PR DESCRIPTION
### 更改1

resolve #170

用 `@mousewheel` 鼠标滚轮控制歌词上下滚动预览，播放到下一句歌词时跳回 

https://github.com/Rocket1184/electron-netease-cloud-music/assets/74091261/96c1551e-7d4d-4baa-9460-4fdfccefac02

### 更改2

resolve #152

调整私人fm新歌曲更新逻辑：

1. 当播放到最后一首歌时，若未获取到新歌曲，则将播放列表第一首歌曲移动到列表末尾而不是在播放完毕后跳转到第一首歌曲
2. 当获取到重复歌曲时，照常添加到播放列表的最后，但将播放列表旧的重复歌曲从列表中删除，而不是直接不添加重复歌曲