### PR TITLE
main: migrate login api to eapi

### DIFF
--- a/src/main/api/httpClient.js
+++ b/src/main/api/httpClient.js
@@ -190,6 +190,15 @@ export default class HttpClient {
         return this.post('https://music.163.com/api/linux/forward', init);
     }
 
+    static EapiDefaultCookies = {
+        os: 'android',
+        osver: '10.0.0',
+        appver: '8.20.30',
+        mobilename: 'linux'
+    };
+    static EapiDefaultCookieString = Object.entries(HttpClient.EapiDefaultCookies)
+        .map(([k, v]) => `${k}=${v}`).join('; ');
+
     /**
      * eapi request
      * @param {string} url
@@ -198,22 +207,17 @@ export default class HttpClient {
      * @param {boolean} useInterfaceUrl
      */
     async postE(url, data = {}, putCacheKey = false, useInterfaceUrl = false) {
-        if (useInterfaceUrl){
-	    url = `https://interface.music.163.com/eapi${url}`;
-	} else {
-	    url = `https://music.163.com/eapi${url}`;
-	}
+        if (useInterfaceUrl) {
+            url = `https://interface.music.163.com/eapi${url}`;
+        } else {
+            url = `https://music.163.com/eapi${url}`;
+        }
         let body = Object.assign({ e_r: 'true' }, data);
         if (putCacheKey) {
             body['cache_key'] = getCacheKey(body);
         }
         // default eapi cookies
-        body.header = Object.assign({
-            os: 'android',
-            osver: '10.0.0',
-            appver: '8.10.20',
-            mobilename: 'linux'
-        }, this.getCookie());
+        body['header'] = Object.assign({}, HttpClient.EapiDefaultCookies, this.getCookie());
         /** @type {import('electron-fetch').RequestInit} */
         let init = {
             method: 'POST',
@@ -223,7 +227,7 @@ export default class HttpClient {
         // encrypt request payload
         init.body = qs.stringify(encodeEApi(new URL(url).pathname, body));
         init.headers = this.mergeHeaders({
-            'Cookie': 'os=android; osver=10.0.0; appver=8.0.0; mobilename=linux',
+            'Cookie': HttpClient.EapiDefaultCookieString,
             'Content-Type': 'application/x-www-form-urlencoded',
             'Content-Length': Buffer.byteLength(init.body)
         });

--- a/src/main/api/httpClient.js
+++ b/src/main/api/httpClient.js
@@ -196,8 +196,12 @@ export default class HttpClient {
      * @param {object} data
      * @param {boolean} putCacheKey
      */
-    async postE(url, data = {}, putCacheKey = false) {
-        url = `https://music.163.com/eapi${url}`;
+    async postE(url, data = {}, putCacheKey = false, interfaceUrl = false) {
+        if (interfaceUrl){
+	    url = `https://interface.music.163.com/eapi${url}`;
+	} else {
+	    url = `https://music.163.com/eapi${url}`;
+	}
         let body = Object.assign({ e_r: 'true' }, data);
         if (putCacheKey) {
             body['cache_key'] = getCacheKey(body);
@@ -218,7 +222,7 @@ export default class HttpClient {
         // encrypt request payload
         init.body = qs.stringify(encodeEApi(new URL(url).pathname, body));
         init.headers = this.mergeHeaders({
-            'Cookie': 'os=android; osver=10.0.0; appver=2.0.3.131777; mobilename=linux',
+            'Cookie': 'os=android; osver=10.0.0; appver=8.0.0; mobilename=linux',
             'Content-Type': 'application/x-www-form-urlencoded',
             'Content-Length': Buffer.byteLength(init.body)
         });

--- a/src/main/api/httpClient.js
+++ b/src/main/api/httpClient.js
@@ -195,9 +195,10 @@ export default class HttpClient {
      * @param {string} url
      * @param {object} data
      * @param {boolean} putCacheKey
+     * @param {boolean} useInterfaceUrl
      */
-    async postE(url, data = {}, putCacheKey = false, interfaceUrl = false) {
-        if (interfaceUrl){
+    async postE(url, data = {}, putCacheKey = false, useInterfaceUrl = false) {
+        if (useInterfaceUrl){
 	    url = `https://interface.music.163.com/eapi${url}`;
 	} else {
 	    url = `https://music.163.com/eapi${url}`;

--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -64,11 +64,11 @@ export function login(acc, pwd, countrycode = '86') {
     };
     if (/^\d*$/.test(acc)) {
         postBody.type = 1;
-        return client.postE('/w/login/cellphone', { phone: acc, countrycode, ...postBody });
+        return client.postE('/w/login/cellphone', { phone: acc, countrycode, ...postBody }, false, true);
         // return client.postW('/login/cellphone', { phone: acc, countrycode, ...postBody });
     } else {
         postBody.type = 0;
-        return client.postE('/w/login', { username: acc, ...postBody });
+        return client.postE('/w/login', { username: acc, ...postBody }, false, true);
         // return client.postW('/login', { username: acc, ...postBody });
     }
 }

--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -58,22 +58,30 @@ export function login(acc, pwd, countrycode = '86') {
     const password = crypto.createHash('md5').update(pwd).digest('hex');
     const postBody = {
         password,
-        rememberLogin: true,
+        remember: true,
+        type: 0,
+        https: true
     };
     if (/^\d*$/.test(acc)) {
-        return client.postW('/login/cellphone', { phone: acc, countrycode, ...postBody });
+        postBody.type = 1;
+        return client.postE('/w/login/cellphone', { phone: acc, countrycode, ...postBody });
+        // return client.postW('/login/cellphone', { phone: acc, countrycode, ...postBody });
     } else {
-        return client.postW('/login', { username: acc, ...postBody });
+        postBody.type = 0;
+        return client.postE('/w/login', { username: acc, ...postBody });
+        // return client.postW('/login', { username: acc, ...postBody });
     }
 }
+
 
 /**
  * 获取扫码登录 key
  * @param {number} [type = 1]
  * @returns {Promise<Types.QRCodeUnikeyRes>}
  */
-export function getQRLoginKey(type = 1) {
-    return client.postW('/login/qrcode/unikey', { type });
+export function getQRLoginKey(type = 3) {
+    return client.postE('/login/qrcode/unikey', { type });
+    // return client.postW('/login/qrcode/unikey', { type });
 }
 
 /**
@@ -86,7 +94,8 @@ export function getQRLoginKey(type = 1) {
  * @param {number} [type = 1]
  */
 export function checkQRLoginStatus(key, type = 1) {
-    return client.postW('/login/qrcode/client/login', { key, type });
+    return client.postE('/login/qrcode/client/login', { key, type });
+    // return client.postW('/login/qrcode/client/login', { key, type });
 }
 
 /**

--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -102,11 +102,11 @@ export function checkQRLoginStatus(key, type = 1) {
  * @returns {Promise<Types.ApiRes>}
  */
 export function refreshLogin() {
-    return client.postW('/login/token/refresh');
+    return client.postE('/login/token/refresh');
 }
 
 export async function logout() {
-    const resp = await client.postW('/logout');
+    const resp = await client.postE('/logout');
     if (resp.code === 200) {
         client.updateCookie();
     }

--- a/src/main/api/index.js
+++ b/src/main/api/index.js
@@ -65,14 +65,11 @@ export function login(acc, pwd, countrycode = '86') {
     if (/^\d*$/.test(acc)) {
         postBody.type = 1;
         return client.postE('/w/login/cellphone', { phone: acc, countrycode, ...postBody }, false, true);
-        // return client.postW('/login/cellphone', { phone: acc, countrycode, ...postBody });
     } else {
         postBody.type = 0;
         return client.postE('/w/login', { username: acc, ...postBody }, false, true);
-        // return client.postW('/login', { username: acc, ...postBody });
     }
 }
-
 
 /**
  * 获取扫码登录 key
@@ -81,7 +78,6 @@ export function login(acc, pwd, countrycode = '86') {
  */
 export function getQRLoginKey(type = 3) {
     return client.postE('/login/qrcode/unikey', { type });
-    // return client.postW('/login/qrcode/unikey', { type });
 }
 
 /**
@@ -95,7 +91,6 @@ export function getQRLoginKey(type = 3) {
  */
 export function checkQRLoginStatus(key, type = 1) {
     return client.postE('/login/qrcode/client/login', { key, type });
-    // return client.postW('/login/qrcode/client/login', { key, type });
 }
 
 /**
@@ -126,7 +121,7 @@ export function verifyCaptcha(id, captcha) {
  * @returns {Promise<Types.MyProfileRes>}
  */
 export function getMyProfile() {
-    return client.postW('/nuser/account/get');
+    return client.postE('/nuser/account/get');
 }
 
 /**
@@ -644,7 +639,7 @@ export function postDailyTaskE(type, adid = 0) {
  * @returns {Promise<Types.GetDailyTaskRes>}
  */
 export function getDailyTask() {
-    return client.postW('/point/getDailyTask');
+    return client.postE('/point/getDailyTask');
 }
 
 /**


### PR DESCRIPTION
fix #182 

1. 参考HyPlayer的 [Commit](https://github.com/HyPlayer/NeteaseCloudMusicAPI/commit/4352f75fe76be67cc4327467fbe035a7d096c84f) 把账号密码登录API迁移到了EAPI以规避网易云对网页端登录API的风控
2. 更新了发送EAPI请求时的Cookie中的appver项，以消除登录时的`版本过旧请更新`的提示

上述更改后可使用账号密码正常登录